### PR TITLE
Fix order of attributes in configuration

### DIFF
--- a/src/WhiteBITServiceProvider.php
+++ b/src/WhiteBITServiceProvider.php
@@ -34,8 +34,8 @@ final class WhiteBITServiceProvider extends BaseServiceProvider
                     new ConnectorConfig(
                         $configRepository->get('whitebit.public_key'),
                         $configRepository->get('whitebit.secret_key'),
-                        $configRepository->get('whitebit.timeout'),
                         $configRepository->get('whitebit.base_url'),
+                        $configRepository->get('whitebit.timeout'),
                     )
                 );
             }


### PR DESCRIPTION
Fixes error:

` TypeError  WhiteBIT\Sdk\Connectors\ConnectorConfig::__construct(): Argument #3 ($baseUrl) must be of type ?string, int given, called in vendor/whitebit/php-sdk/src/WhiteBITServiceProvider.php on line 34.`
<img width="543" alt="Снимок экрана 2023-11-27 в 16 43 06" src="https://github.com/whitebit-exchange/php-sdk/assets/4211508/4055b552-7213-4bf2-a56b-561ec53427dc">
